### PR TITLE
I added a new file in example that sets up a uniform sphere of ions a…

### DIFF
--- a/examples/molecular_plasma_simulation_scaled.py
+++ b/examples/molecular_plasma_simulation_scaled.py
@@ -1,0 +1,144 @@
+import uci.BorisUpdater as BorisUpdater
+import uci.CoulombAccScaled as CoulombAccScaled
+import uci.Ptcls as Ptcls
+import numpy as np
+import pyopencl as cl
+import pyopencl.array as cl_array
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(
+        description=
+        """Simulate evolution of a plasma starting from a random
+        configuration""")
+parser.add_argument('-t', '--tmax',
+        nargs=1,
+        help='Duration of simulation in plasma periods',
+        type=float,
+        default=1.0)
+parser.add_argument('-d', '--dt',
+        nargs=1,
+        help='Integrator time step size',
+        type=float,
+        default=0.01)
+parser.add_argument('-n', '--n_ions',
+        nargs=1,
+        help='Number of ions/electrons',
+        type=int,
+        default=250)
+parser.add_argument('-o', '--num_dump',
+        nargs=1,
+        help='Number of time steps between dumps of plasma state',
+        type=int,
+        default=10)
+
+class UsageError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+Epsilon = 8.854187817620e-12
+fund_charge_SI = 1.602176565e-19
+fund_charge = 1.0
+atomic_unit = 1.836152675241972e+03
+ion_mass = 29.783981668036578 * atomic_unit
+electron_mass_SI = 9.10938291e-31
+electron_mass = 1.0
+kB = 1.3806e-23
+
+def run_simulation(n_ions, dt, tmax, num_dump = 1):
+    # initialize particles
+    ptcls = Ptcls.Ptcls()
+    ptcls.set_nptcls(2 * n_ions)
+    density = 1.0e+18
+    volume = n_ions / density
+    l = (3 * volume / 4 / np.pi)**(1./3.)
+    a_ws = (3 /( 4 * np.pi * density))**(1./3.)
+    l = l / a_ws
+    # electron plasma frequency is used to scale time t -> t * w_e
+    w_e = np.sqrt(density * fund_charge_SI**2 / (electron_mass_SI * Epsilon))
+
+    # ions
+    i = 0
+    while i < n_ions:
+        xt = (np.random.random()-0.5)*l*2
+        yt = (np.random.random()-0.5)*l*2
+        zt = (np.random.random()-0.5)*l*2
+        rt = np.sqrt(xt**2+yt**2+zt**2)
+        if rt <= l:
+            ptcls.x()[i] = xt
+            ptcls.y()[i] = yt
+            ptcls.z()[i] = zt
+            i += 1
+    ptcls.ptclList[3:6,:n_ions] = 0
+    ptcls.ptclList[6,:n_ions] = fund_charge
+    ptcls.ptclList[7,:n_ions] = ion_mass
+
+    #electrons
+    i = 0
+    while i < n_ions:
+        xt = (np.random.random()-0.5)*l*2
+        yt = (np.random.random()-0.5)*l*2
+        zt = (np.random.random()-0.5)*l*2
+        rt = np.sqrt(xt**2+yt**2+zt**2)
+        if rt <= l:
+            ptcls.x()[n_ions+i] = xt
+            ptcls.y()[n_ions+i] = yt
+            ptcls.z()[n_ions+i] = zt
+            i += 1
+  
+    electron_temperature = 3.0
+    vThermal = np.sqrt(kB * electron_temperature / electron_mass_SI)
+    vThermal = vThermal / (a_ws * w_e)
+    ptcls.ptclList[3:6,n_ions:] = np.random.normal(
+            0.0, vThermal, ptcls.ptclList[3:6,n_ions:].shape)
+    ptcls.ptclList[6,n_ions:] = -fund_charge
+    ptcls.ptclList[7,n_ions:] = electron_mass
+
+
+    ctx = cl.create_some_context(interactive = True)
+    queue = cl.CommandQueue(ctx)
+    coulomb_acc = CoulombAccScaled.CoulombAccScaled(ctx, queue)
+    accelerations = [coulomb_acc]
+    updater = BorisUpdater.BorisUpdater(ctx, queue)
+
+    xd = cl_array.to_device(queue, ptcls.x())
+    yd = cl_array.to_device(queue, ptcls.y())
+    zd = cl_array.to_device(queue, ptcls.z())
+    vxd = cl_array.to_device(queue, ptcls.vx())
+    vyd = cl_array.to_device(queue, ptcls.vy())
+    vzd = cl_array.to_device(queue, ptcls.vz())
+    qd = cl_array.to_device(queue, ptcls.q())
+    md = cl_array.to_device(queue, ptcls.m())
+    
+    t = 0.0
+    while t < tmax:
+        #np.save('data\ptcls' + str(t) + '.npy',ptcls.ptclList[0:6,:])
+        np.savetxt('data\ptcls' + str(t) + '.txt',ptcls.ptclList[0:6,:])
+        t = updater.update(
+                xd, yd, zd, vxd, vyd, vzd, qd, md, accelerations, t, dt,
+                num_dump)
+        xd.get(queue, ptcls.x())
+        yd.get(queue, ptcls.y())
+        zd.get(queue, ptcls.z())
+        vxd.get(queue, ptcls.vx())
+        vyd.get(queue, ptcls.vy())
+        vzd.get(queue, ptcls.vz())
+
+    np.savetxt('data\ptcls' + str(t) + '.txt',ptcls.ptclList[0:6,:])
+
+def main(argv=None):
+    try:
+        try:
+            args = parser.parse_args(argv)
+        except Exception as msg:
+            raise UsageError(msg)
+
+        run_simulation(args.n_ions, args.dt, args.tmax, args.num_dump)
+
+    except UsageError as err:
+        print >>sys.stderr, err.msg
+        print >>sys.stderr, 'For help use --help'
+        return 2
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/test_CoulombAccScaled.py
+++ b/test/test_CoulombAccScaled.py
@@ -1,0 +1,140 @@
+import uci.CoulombAccScaled as uci
+import numpy as np
+import pyopencl as cl
+import pyopencl.array as cl_array
+
+testCtx = cl.create_some_context(interactive = True)
+testQueue = cl.CommandQueue(testCtx)
+
+def test_Constructor():
+    coulomb_acc = uci.CoulombAccScaled()
+
+def test_ForceOnSingleParticleIsZero():
+    coulomb_acc = uci.CoulombAccScaled(testCtx, testQueue)
+    one = np.ones(1)
+    ax = np.zeros(1)
+    ay = np.zeros(1)
+    az = np.zeros(1)
+
+    xd = cl_array.to_device(testQueue, one)
+    yd = cl_array.to_device(testQueue, one)
+    zd = cl_array.to_device(testQueue, one)
+    vxd = cl_array.to_device(testQueue, one)
+    vyd = cl_array.to_device(testQueue, one)
+    vzd = cl_array.to_device(testQueue, one)
+    qd = cl_array.to_device(testQueue, one)
+    md = cl_array.to_device(testQueue, one)
+    axd = cl_array.to_device(testQueue, ax)
+    ayd = cl_array.to_device(testQueue, ay)
+    azd = cl_array.to_device(testQueue, az)
+
+    coulomb_acc.computeAcc(xd, yd, zd, vxd, vyd, vzd, qd, md,
+            axd, ayd, azd, 0)
+
+    axd.get(testQueue, ax)
+    ayd.get(testQueue, ay)
+    azd.get(testQueue, az)
+    assert ax[0] == 0
+    assert ay[0] == 0
+    assert az[0] == 0
+    
+
+def test_TwoParticlesWithEqualChargeRepelEachOther():
+    coulomb_acc = uci.CoulombAccScaled(testCtx, testQueue)
+    one = np.ones(2)
+    ax = np.zeros(2)
+    ay = np.zeros(2)
+    az = np.zeros(2)
+
+    x = np.array([0.1, 1])
+    y = np.array([0.2, 2.3])
+    z = np.array([0.3, 2.7])
+    xd = cl_array.to_device(testQueue, x)
+    yd = cl_array.to_device(testQueue, y)
+    zd = cl_array.to_device(testQueue, z)
+    vxd = cl_array.to_device(testQueue, one)
+    vyd = cl_array.to_device(testQueue, one)
+    vzd = cl_array.to_device(testQueue, one)
+    qd = cl_array.to_device(testQueue, one)
+    md = cl_array.to_device(testQueue, one)
+    axd = cl_array.to_device(testQueue, ax)
+    ayd = cl_array.to_device(testQueue, ay)
+    azd = cl_array.to_device(testQueue, az)
+
+    coulomb_acc.computeAcc(xd, yd, zd, vxd, vyd, vzd, qd, md,
+            axd, ayd, azd, 0)
+
+    axd.get(testQueue, ax)
+    ayd.get(testQueue, ay)
+    azd.get(testQueue, az)
+    assert ax[0] != 0
+    assert np.abs(ax[0] + ax[1]) < 1.0e-6
+    assert np.abs(ay[0] + ay[1]) < 1.0e-6
+    assert np.abs(az[0] + az[1]) < 1.0e-6
+
+
+def reference_solution(x, y, z, vx, vy, vz, q, m, ax, ay, az):
+    for i in range(x.size):
+        for j in range(x.size):
+            prefactor = 1.0 / 3.0 * q[i] * q[j]
+            r = np.sqrt(
+                    (x[i] - x[j]) * (x[i] - x[j]) +
+                    (y[i] - y[j]) * (y[i] - y[j]) +
+                    (z[i] - z[j]) * (z[i] - z[j]) +
+                    0.05**2
+                    )
+            rCubed = np.power(r, 3.0)
+            ax[i] += prefactor * (x[i] - x[j]) / rCubed / m[i]
+            ay[i] += prefactor * (y[i] - y[j]) / rCubed / m[i]
+            az[i] += prefactor * (z[i] - z[j]) / rCubed / m[i]
+
+
+def compareWithReferenceSol(n):
+    coulomb_acc = uci.CoulombAccScaled(testCtx, testQueue)
+    x = np.random.random_sample(n) - 0.5
+    y = np.random.random_sample(n) - 0.5
+    z = np.random.random_sample(n) - 0.5
+    vx = np.random.random_sample(n) - 0.5
+    vy = np.random.random_sample(n) - 0.5
+    vz = np.random.random_sample(n) - 0.5
+    q = np.random.random_sample(n) - 0.5
+    m = np.random.random_sample(n) - 0.5
+    ax = np.zeros(n)
+    ay = np.zeros(n)
+    az = np.zeros(n)
+
+    xd = cl_array.to_device(testQueue, x)
+    yd = cl_array.to_device(testQueue, y)
+    zd = cl_array.to_device(testQueue, z)
+    vxd = cl_array.to_device(testQueue, vx)
+    vyd = cl_array.to_device(testQueue, vy)
+    vzd = cl_array.to_device(testQueue, vz)
+    qd = cl_array.to_device(testQueue, q)
+    md = cl_array.to_device(testQueue, m)
+    axd = cl_array.to_device(testQueue, ax)
+    ayd = cl_array.to_device(testQueue, ay)
+    azd = cl_array.to_device(testQueue, az)
+
+    coulomb_acc.computeAcc(xd, yd, zd, vxd, vyd, vzd, qd, md,
+            axd, ayd, azd, 0)
+
+    axd.get(testQueue, ax)
+    ayd.get(testQueue, ay)
+    azd.get(testQueue, az)
+
+    ax_ref = np.zeros(n)
+    ay_ref = np.zeros(n)
+    az_ref = np.zeros(n)
+    reference_solution(x, y, z, vx, vy, vz, q, m, ax_ref, ay_ref, az_ref)
+    for i in range(n):
+        assert np.abs(ax[i] - ax_ref[i]) / (np.abs(ax[i]) + np.abs(ax_ref[i])) < 1.0e-6
+
+
+def test_SmallSystem():
+    compareWithReferenceSol(10)
+
+
+def test_PowerOfTwo():
+    compareWithReferenceSol(128)
+
+

--- a/uci/CoulombAccScaled.py
+++ b/uci/CoulombAccScaled.py
@@ -1,0 +1,117 @@
+import numpy
+import uci.Ptcls as Ptcls
+import pyopencl as cl
+import pyopencl.array as cl_array
+import sys
+import os
+import math
+
+
+class CoulombAccScaled():
+
+    BLOCK_SIZE = 256
+    PTCL_UNROLL_FACTOR = 1
+
+    maxNumThreadsX = 2**12
+
+    k = 1.0/3.0
+    impactFact = 0.05**2 
+
+    def __init__(self, ctx = None, queue = None):
+        self.ctx = ctx
+        self.queue = queue
+        if self.ctx == None:
+            self.ctx = cl.create_some_context()
+        if self.queue == None:
+            self.queue = cl.CommandQueue(self.ctx,
+                properties=cl.command_queue_properties.PROFILING_ENABLE)
+        self.mf = cl.mem_flags
+
+        absolutePathToKernels = os.path.dirname(
+                os.path.realpath(__file__))
+        src = open(absolutePathToKernels + '/compute_coulomb_acceleration.cl', 
+                'r').read()
+
+        self.compAccF = cl.Program(self.ctx, src)
+        try:
+            self.compAccF.build(options = [
+              ' -DBLOCK_SIZE=' + str(self.BLOCK_SIZE) +
+              ' -DPTCL_UNROLL_FACTOR=' + str(self.PTCL_UNROLL_FACTOR)])
+        except:
+              print("Error:")
+              print(self.compAccF.get_build_info(self.ctx.devices[0],
+                          cl.program_build_info.LOG))
+              raise
+        self.compAccF.compute_coulomb_acceleration.set_scalar_arg_dtypes(
+                [None, None, None, None, None, None, None, None,
+                numpy.float32, numpy.float32, numpy.int32, None, None,
+                None])
+
+        self.compAccD = cl.Program(self.ctx, src)
+        try:
+            self.compAccD.build(options = [
+              ' -DUSE_DOUBLE=TRUE -DBLOCK_SIZE=' + str(self.BLOCK_SIZE) +
+              ' -DPTCL_UNROLL_FACTOR=' + str(self.PTCL_UNROLL_FACTOR)])
+        except:
+              print("Error:")
+              print(self.compAccD.get_build_info(self.ctx.devices[0],
+                          cl.program_build_info.LOG))
+              raise
+        self.compAccD.compute_coulomb_acceleration.set_scalar_arg_dtypes(
+                [None, None, None, None, None, None, None, None,
+                numpy.float64, numpy.float64, numpy.int32, None, None,
+                None])
+
+
+    def computeAcc(self, xd, yd, zd, vxd, vyd, vzd, qd, md, axd, ayd,
+            azd, t, dt = None):
+        """ 
+           Compute acceleration due to coulomb forces between particles.
+           All variables are device arrays.  They are assumed to be the
+           same length and precision.  The computed accelerations are
+           accumulated into the a?d arrays (i.e. the a?d arrays are not
+           set to zero).
+        """
+
+        self.computeLaunchConfig(xd.size)
+
+        prec = xd.dtype
+        if prec == numpy.float32:
+            self.compAccF.compute_coulomb_acceleration(self.queue,
+               (self.numThreadsX, self.numThreadsY),
+               (self.BLOCK_SIZE, 1),
+               xd.data, yd.data, zd.data,
+               vxd.data, vyd.data, vzd.data,
+               qd.data, md.data,
+               numpy.float32(self.k), numpy.float32(self.impactFact), 
+               numpy.int32(xd.size),
+               axd.data, ayd.data, azd.data,
+               g_times_l = False)
+        elif prec == numpy.float64:
+            self.compAccD.compute_coulomb_acceleration(self.queue,
+               (self.numThreadsX, self.numThreadsY),
+               (self.BLOCK_SIZE, 1),
+               xd.data, yd.data, zd.data,
+               vxd.data, vyd.data, vzd.data,
+               qd.data, md.data,
+               numpy.float64(self.k), numpy.float64(self.impactFact), 
+               numpy.int32(xd.size),
+               axd.data, ayd.data, azd.data,
+               g_times_l = False)
+        else:
+            print("Unknown float type.")
+
+
+    def computeLaunchConfig(self, numPtcls):
+        self.numThreads = int(math.ceil(float(numPtcls) / self.PTCL_UNROLL_FACTOR))
+        self.numThreadsX = self.BLOCK_SIZE * int(math.ceil(float(self.numThreads) / 
+                        float(self.BLOCK_SIZE)))
+        if self.numThreadsX > self.maxNumThreadsX:
+            self.numThreadsX = self.maxNumThreadsX
+        self.numThreadsY = int(math.ceil(float(self.numThreads) / 
+                    float(self.numThreadsX)))
+
+
+# vi: ts=4 sw=4
+#
+


### PR DESCRIPTION
…nd initiates a plasma simulation and it implements scaling
The two files are new, so nothing else is changed. The first file is the copy of unpFromLattice. It is modified to set up a random configuration of ions as well as electrons all in a form of a sphere. The position and velocity are scaled and ready to be integrated by CulombAccScaled.py

The second file is CulombAccScaled.py which is the copy of CulombAcc.py, with few small changes that implements scaling. For example the force is now simply F = (xi - xj)/rij^3/3, where x and r are scaled coordinate and distances. The scaling parameter for distance is the wigner-seitz radius and the scaling factor for time is the electron plasma period. Just as well the electron mass and charge are equal to unity.
